### PR TITLE
Update config links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,13 +19,13 @@ description: > # this means to ignore newlines until "baseurl:"
   and syntax highlighting, built on HTTPie and prompt_toolkit.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://http-prompt.com" # the base hostname & protocol for your site, e.g. http://example.com
-docs_url: "http://docs.http-prompt.com"
-docs_baseurl: "http://docs.http-prompt.com/en/latest"
-github_url: "https://github.com/eliangcs/http-prompt"
+docs_url: "https://docs.http-prompt.com"
+docs_baseurl: "https://docs.http-prompt.com/en/latest"
+github_url: "https://github.com/httpie/http-prompt"
 gitter_url: "https://gitter.im/eliangcs/http-prompt"
 producthunt_url: "https://www.producthunt.com/posts/http-prompt"
-license_url: "https://github.com/eliangcs/http-prompt/blob/master/LICENSE"
-comm_license_url: "https://github.com/eliangcs/http-prompt/blob/master/COMM-LICENSE"
+license_url: "https://github.com/httpie/http-prompt/blob/master/LICENSE"
+comm_license_url: "https://github.com/httpie/http-prompt/blob/master/LICENSE"
 creator_github_url: "https://github.com/eliangcs"
 creator_name: "Chang-Hung Liang"
 


### PR DESCRIPTION
1. New @httpie org repo location
2. HTTPS for `docs.*`
3. Fallback commercial licence link as it was removed in https://github.com/httpie/http-prompt/pull/115/commits/7b1369a8bf314a9ada17ffb2eb44af2d6b211eaa (instead of a 404 boo boo the current MIT is linked; alternatively could be removed altogether once `_includes/checkout_form_*` stop using it…)